### PR TITLE
Update try! interface, port forward to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "credibility"
 version = "0.1.4-dev"
 authors = ["Andreas Fuchs <asf@boinkor.net>"]
@@ -22,5 +23,3 @@ circle-ci = { repository = "antifuchs/credibility", branch = "master" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-failure = "0.1.1"
-failure_derive = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate failure;
-
 mod macros;
 mod reporter;
 pub mod selftest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ mod reporter;
 pub mod selftest;
 mod test_block;
 
-pub use macros::*;
-pub use reporter::*;
-pub use test_block::*;
+pub use crate::macros::*;
+pub use crate::reporter::*;
+pub use crate::test_block::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,7 +12,6 @@
 /// # fn main() {
 /// test_block!(tb, "An example test block", {
 ///     aver!(tb, true, "A working assertion");
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -32,7 +31,6 @@
 ///     for (in1, in2, output) in cases {
 ///         aver!(tb, in1+in2 != output);
 ///     }
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -58,7 +56,6 @@ macro_rules! aver {
 /// # fn main() {
 /// test_block!(tb, "An example test block", {
 ///     aver_eq!(tb, 2+3, 5, "Math should work!");
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -80,7 +77,6 @@ macro_rules! aver {
 ///         let result = in1+in2+1;
 ///         aver_eq!(tb, output, result);
 ///     }
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -106,7 +102,6 @@ macro_rules! aver_eq {
 /// # fn main() {
 /// test_block!(tb, "An example test block", {
 ///     aver_ne!(tb, 2+4, 5, "Math should work!");
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -128,7 +123,6 @@ macro_rules! aver_eq {
 ///         let result = in1+in2;
 ///         aver_ne!(tb, output, result);
 ///     }
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -185,7 +179,6 @@ macro_rules! aver_ne {
 ///     for (in1, in2, output) in cases {
 ///         aver_eq!(tb, output, in1+in2);
 ///     }
-///     Ok(())
 /// });
 /// # }
 /// ```
@@ -193,8 +186,7 @@ macro_rules! aver_ne {
 /// An example of how to handle error results in tests:
 /// ``` rust, should_panic
 /// # #[macro_use] extern crate credibility;
-/// # #[macro_use] extern crate failure;
-/// # fn fail() -> Result<(), failure::Error> { Err(format_err!("this test should fail")) }
+/// # fn fail() -> Result<(), &'static str> { Err("this test should fail") }
 /// # fn main() {
 /// test_block!(tb, "An example test block that should fail", {
 ///     fail()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -139,17 +139,7 @@ macro_rules! aver_ne {
 ///
 /// `test_block` is a convenience macro (that's very convenient!) for
 /// running tests in bulk and causing a test abort based on their
-/// results once the block terminates. The block of code runs in a
-/// closure defined to return a `Result`, so within the block, `?` and
-/// `try!` work correctly.
-///
-/// # Handling `Result`
-///
-/// Since `test_block!` executes code inside a closure that returns a
-/// Result, test code can use `?` within that block, to short-circuit
-/// error handling without unsightly `.unwrap()` calls. The
-/// unfortunate consequence of this is that code blocks within
-/// `test_block!` macros must return `Ok(())` at the end.
+/// results once the block terminates.
 ///
 /// # Teardown behavior
 /// The behavior at the end of the block depends on the
@@ -163,6 +153,21 @@ macro_rules! aver_ne {
 /// [`TestReporter`](trait.TestReporter.html) argument to customize
 /// this behavior; see the module [`selftest`](selftest/index.html)
 /// for an example.
+///
+/// # Compatibility with test functions that return `Result`s
+///
+/// `test_block` properly treats blocks that use the `?` postfix operator
+/// to handle `Result`s in tests that return `Result` types (see [the
+/// book][using-results-in-tests]). The test block block is evaluated
+/// inside the test function, and whenever a `?` usage would abort and
+/// return an error result early, the test function will do just that.
+///
+/// In other words, using `?` in these functions is the equivalent of
+/// [`testify`][testify]'s `require` functions, which will abort and fail the test
+/// early because it can not continue.
+///
+/// [using-results-in-tests]: https://doc.rust-lang.org/book/ch11-01-writing-tests.html#using-resultt-e-in-tests
+/// [testify]: https://github.com/stretchr/testify#require-package
 ///
 /// # Examples
 ///
@@ -184,27 +189,30 @@ macro_rules! aver_ne {
 /// ```
 ///
 /// An example of how to handle error results in tests:
-/// ``` rust, should_panic
+/// ``` rust,should_panic
 /// # #[macro_use] extern crate credibility;
 /// # fn fail() -> Result<(), &'static str> { Err("this test should fail") }
-/// # fn main() {
+/// # fn main() -> Result<(), &'static str> {
 /// test_block!(tb, "An example test block that should fail", {
-///     fail()
-/// });
+///     fail()?;
+///     Ok(())
+/// })
 /// # }
 /// ```
 #[macro_export]
 macro_rules! test_block {
     ($block:ident, $tracker:ident, $name:expr, $code:block) => {{
         let mut $block = $crate::TestBlock::new($name, &mut $tracker);
-        let result = {
-            let mut fun = || $code;
-            fun()
-        };
-        $block.ran(result);
+        let res = { $code };
+        // $code might panic, so this might never be reached:
+        #[allow(unreachable_code)]
+        {
+            $block.finished();
+            res
+        }
     }};
     ($block:ident, $name:expr, $code:block) => {{
         let mut tracker = $crate::DefaultTestReporter::default();
-        test_block!($block, tracker, $name, $code);
+        test_block!($block, tracker, $name, $code)
     }};
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -9,10 +9,8 @@ pub trait TestReporter {
     /// kind, the `aver!` failed, indicating that the test should fail.
     fn averred<T: Sized + Debug>(&mut self, result: thread::Result<T>);
 
-    /// Invoked whenever a test block finished. If result is an `Err`,
-    /// indicates that the block failed. This means that the test
-    /// should abort.
-    fn ran<T: Send + Sized + Debug, E: Send + Sized + Debug>(&mut self, result: Result<T, E>);
+    /// Invoked whenever a test block finishes.
+    fn ran(&mut self);
 
     /// Invoked at the end of life of a test block.
     ///
@@ -43,35 +41,11 @@ impl TestReporter for DefaultTestReporter {
         }
     }
 
-    fn ran<T: Sized + Debug, E: Sized + Debug>(&mut self, result: Result<T, E>) {
-        result.expect("Unexpected error result");
-    }
+    fn ran(&mut self) {}
 
     fn tally<'a>(&self, name: &'a str) {
         if self.failed {
             panic!("Test cases in block {:?} failed", name);
         }
-    }
-}
-
-#[derive(Debug)]
-#[doc(hidden)]
-pub struct TestBlockResult<T: Debug + Sized, E: Debug + Sized>(Result<T, E>);
-
-impl<T: Debug + Sized, E: Debug + Sized> TestBlockResult<T, E> {
-    pub fn result(self) -> Result<T, E> {
-        self.0
-    }
-}
-
-impl From<()> for TestBlockResult<(), ()> {
-    fn from(_nothing: ()) -> TestBlockResult<(), ()> {
-        TestBlockResult(Ok(()))
-    }
-}
-
-impl<T: Debug + Sized, E: Debug + Sized> From<Result<T, E>> for TestBlockResult<T, E> {
-    fn from(res: Result<T, E>) -> TestBlockResult<T, E> {
-        TestBlockResult(res)
     }
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -70,7 +70,7 @@ impl From<()> for TestBlockResult<(), ()> {
     }
 }
 
-impl<T: Debug + Send, E: Debug + Send> From<Result<T, E>> for TestBlockResult<T, E> {
+impl<T: Debug + Sized, E: Debug + Sized> From<Result<T, E>> for TestBlockResult<T, E> {
     fn from(res: Result<T, E>) -> TestBlockResult<T, E> {
         TestBlockResult(res)
     }

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -1,10 +1,8 @@
 //! Structs and functions to enable testing `credibility` itself
-use crate::TestReporter;
+use crate::{TestBlockResult, TestReporter};
 
 use std::fmt::Debug;
 use std::thread;
-
-use failure;
 
 /// A test reporter that counts the number of things that
 /// happened. It's mostly useful for writing tests.
@@ -39,11 +37,12 @@ impl TestReporter for TestTracker {
         }
     }
 
-    fn ran<T: Sized + Debug>(&mut self, result: Result<T, failure::Error>) {
+    fn ran<T: Sized + Debug, E: Sized + Debug>(&mut self, result: TestBlockResult<T, E>) {
         println!("run result: {:?}", result);
-        match result {
-            Err(_) => self.errored += 1,
-            Ok(_) => self.ran += 1,
+        match result.res {
+            Some(Err(_)) => self.errored += 1,
+            Some(Ok(_)) => self.ran += 1,
+            None => self.ran += 1,
         }
     }
 

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -1,5 +1,5 @@
 //! Structs and functions to enable testing `credibility` itself
-use TestReporter;
+use crate::TestReporter;
 
 use std::fmt::Debug;
 use std::thread;

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -1,5 +1,5 @@
 //! Structs and functions to enable testing `credibility` itself
-use crate::{TestBlockResult, TestReporter};
+use crate::TestReporter;
 
 use std::fmt::Debug;
 use std::thread;
@@ -37,12 +37,11 @@ impl TestReporter for TestTracker {
         }
     }
 
-    fn ran<T: Sized + Debug, E: Sized + Debug>(&mut self, result: TestBlockResult<T, E>) {
+    fn ran<T: Sized + Debug, E: Sized + Debug>(&mut self, result: Result<T, E>) {
         println!("run result: {:?}", result);
-        match result.res {
-            Some(Err(_)) => self.errored += 1,
-            Some(Ok(_)) => self.ran += 1,
-            None => self.ran += 1,
+        match result {
+            Err(_) => self.errored += 1,
+            Ok(_) => self.ran += 1,
         }
     }
 

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -9,7 +9,6 @@ use std::thread;
 #[derive(Copy, Clone)]
 pub struct TestTracker {
     failed: usize,
-    errored: usize,
     succeeded: usize,
     ran: usize,
 }
@@ -19,7 +18,6 @@ impl Default for TestTracker {
         TestTracker {
             failed: 0,
             succeeded: 0,
-            errored: 0,
             ran: 0,
         }
     }
@@ -37,12 +35,9 @@ impl TestReporter for TestTracker {
         }
     }
 
-    fn ran<T: Sized + Debug, E: Sized + Debug>(&mut self, result: Result<T, E>) {
-        println!("run result: {:?}", result);
-        match result {
-            Err(_) => self.errored += 1,
-            Ok(_) => self.ran += 1,
-        }
+    fn ran(&mut self) {
+        println!("test block finished result");
+        self.ran += 1;
     }
 
     /// Does nothing. To get information about a test block's statuses
@@ -56,7 +51,7 @@ impl TestTracker {
     /// * succeeded assertions
     /// * blocks that returned an Err result
     /// * blocks that returned an Ok result
-    pub fn counts(&self) -> (usize, usize, usize, usize) {
-        (self.failed, self.succeeded, self.errored, self.ran)
+    pub fn counts(&self) -> (usize, usize, usize) {
+        (self.failed, self.succeeded, self.ran)
     }
 }

--- a/src/test_block.rs
+++ b/src/test_block.rs
@@ -1,6 +1,7 @@
-use failure;
+use std::fmt::Debug;
 use std::panic::{catch_unwind, UnwindSafe};
 
+use super::TestBlockResult;
 use super::TestReporter;
 
 /// A RAII test result accumulator.  The `TestBlock` defines a unit of
@@ -47,8 +48,11 @@ where
     }
 
     /// Called at the end of a block of code that returns a `Result`.
-    pub fn ran(&mut self, res: Result<(), failure::Error>) {
-        self.status_tracker.ran(res);
+    pub fn ran<T: Send + Sized + Debug, E: Send + Sized + Debug>(
+        &mut self,
+        res: impl Into<TestBlockResult<T, E>>,
+    ) {
+        self.status_tracker.ran(res.into());
     }
 }
 

--- a/src/test_block.rs
+++ b/src/test_block.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use std::panic::{catch_unwind, UnwindSafe};
 
 use super::TestReporter;

--- a/src/test_block.rs
+++ b/src/test_block.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::panic::{catch_unwind, UnwindSafe};
 
-use super::TestBlockResult;
 use super::TestReporter;
 
 /// A RAII test result accumulator.  The `TestBlock` defines a unit of
@@ -47,13 +46,8 @@ where
         self.status_tracker.averred(res);
     }
 
-    /// Called at the end of a block of code that returns a `Result`.
-    pub fn ran<T: Send + Sized + Debug, E: Send + Sized + Debug>(
-        &mut self,
-        res: impl Into<TestBlockResult<T, E>>,
-    ) {
-        let res = res.into();
-        self.status_tracker.ran(res.result());
+    pub fn finished(&mut self) {
+        self.status_tracker.ran()
     }
 }
 

--- a/src/test_block.rs
+++ b/src/test_block.rs
@@ -52,7 +52,8 @@ where
         &mut self,
         res: impl Into<TestBlockResult<T, E>>,
     ) {
-        self.status_tracker.ran(res.into());
+        let res = res.into();
+        self.status_tracker.ran(res.result());
     }
 }
 

--- a/tests/credibility.rs
+++ b/tests/credibility.rs
@@ -1,13 +1,10 @@
 #[macro_use]
 extern crate credibility;
-#[macro_use]
-extern crate failure;
 
 use credibility::selftest::*;
 
-fn failure_result() -> Result<(), failure::Error> {
-    Err(format_err!("nope!"))?;
-    Ok(())
+fn failure_result() -> Result<(), &'static str> {
+    Err("nope!")
 }
 
 #[test]
@@ -21,7 +18,6 @@ fn aver_failures() {
             {
                 aver!(tb, false, "Executed");
                 aver!(tb, false, "Also executed");
-                Ok(())
             }
         );
     }
@@ -40,7 +36,6 @@ fn aver_eq() {
                 aver_eq!(tb, false, false, "Equal");
                 aver_eq!(tb, true, false, "Not equal");
                 aver_eq!(tb, true, false, "Not equal, again");
-                Ok(())
             }
         );
     }
@@ -59,7 +54,6 @@ fn aver_ne() {
                 aver_ne!(tb, false, false, "Equal");
                 aver_ne!(tb, true, false, "Not equal");
                 aver_ne!(tb, true, false, "Not equal, again");
-                Ok(())
             }
         );
     }
@@ -80,7 +74,6 @@ fn aver_table() {
                     let sum = in1 + in2;
                     aver_eq!(tb, sum, output);
                 }
-                Ok(())
             }
         );
     }
@@ -94,7 +87,6 @@ fn aver_success() {
         test_block!(tb, tracker, "Checking that aver successes count", {
             aver!(tb, true, "Executed");
             aver!(tb, true, "Also executed");
-            Ok(())
         });
     }
     assert_eq!(tracker.counts(), (0, 2, 0, 1));
@@ -115,7 +107,7 @@ fn err_result() {
 fn ok_result() {
     let mut tracker = TestTracker::default();
     {
-        test_block!(tb, tracker, "asserting that success is OK", { Ok(()) });
+        test_block!(tb, tracker, "asserting that success is OK", {});
     }
     assert_eq!(tracker.counts(), (0, 0, 0, 1));
 }

--- a/tests/test_reporter.rs
+++ b/tests/test_reporter.rs
@@ -28,16 +28,16 @@ fn aver_with_default_reporter() {
     .is_err());
 }
 
-fn error_result() -> Result<(), &'static str> {
-    return Err("I should fail");
+fn error_result() -> Result<(), ()> {
+    return Err(());
 }
 
 #[test]
 fn err_result_with_default_reporter() {
-    assert!(catch_unwind(|| {
+    assert_eq!(
+        Err(()),
         test_block!(inner_tb, "Block with a default test reporter", {
             error_result()
-        });
-    })
-    .is_err());
+        })
+    );
 }

--- a/tests/test_reporter.rs
+++ b/tests/test_reporter.rs
@@ -2,8 +2,6 @@
 
 #[macro_use]
 extern crate credibility;
-#[macro_use]
-extern crate failure;
 
 use std::panic::catch_unwind;
 
@@ -25,17 +23,20 @@ fn aver_with_default_reporter() {
         test_block!(inner_tb, "Block with a default test reporter", {
             aver!(inner_tb, false, "Executed");
             aver!(inner_tb, false, "Also executed");
-            Ok(())
         });
     })
     .is_err());
+}
+
+fn error_result() -> Result<(), &'static str> {
+    return Err("I should fail");
 }
 
 #[test]
 fn err_result_with_default_reporter() {
     assert!(catch_unwind(|| {
         test_block!(inner_tb, "Block with a default test reporter", {
-            Err(format_err!("I should fail!"))
+            error_result()
         });
     })
     .is_err());


### PR DESCRIPTION
This PR updates credibility to the 2018 edition and adjusts to allow inclusion in Result-returning test functions, to allow use of `?` in more places.

More detailed list:

* Remove use of `failure` crate, mandate that Err results only be `Sized + Debug`
* Make the test block runner compatible with `Result`-returning test functions - unless a test block returns a `Result`, the underlying test function does not have to return a `Result` either; that also means that you can't use `?` to early-return from a test block unless the function returns a `Result`, but that seems reasonable.
* Document the new state of the world & introduce a few test cases.